### PR TITLE
Game info separation

### DIFF
--- a/base_map/base_map_manager.c
+++ b/base_map/base_map_manager.c
@@ -22,8 +22,8 @@
 #include "map.h"
 #include "data.h"
 #include "draw_base_map.h"
-#include "draw_players.h"
 #include "game_info.h"
+#include "draw_players.h"
 #include "game_map.h"
 #include "base_map_manager.h"
 
@@ -52,27 +52,18 @@ t_map	init_t_map(SDL_Rect src, SDL_Rect dest, texture_type type)
   return (map);
 }
 
-void		*draw_all(void *arg)
+int		draw_fixed_map(void *arg)
 {
-  int		i;
-  t_game_info	*game_info;
-  
-  game_info = get_game_info();
-  draw_map_model(arg);
-  draw_pannel(arg);
-  draw_timer(arg);
-  if (game_info != NULL)
-    {
-      for (i = 0; i < 4; i++)
-	{
-	  if (game_info->players[i].connected && game_info->players[i].alive)
-	    draw_player(arg, game_info->players[i]);
-	}
-    }
-  return (NULL);
+  if (draw_map_model(arg) == NULL)
+    return (0);
+  if (!draw_pannel(arg))
+    return (0);
+  if (!draw_timer(arg))
+    return (0);
+  return (1);
 }
 
-void		*rebuild_map(void *arg) {
+void		rebuild_map(void *arg) {
   t_data	*data = (t_data*)arg;
   int		i, j;
 
@@ -88,7 +79,6 @@ void		*rebuild_map(void *arg) {
 	    }
 	}
     }
-  return (NULL);
 }
 
 void		build_destroyables(void *arg)

--- a/base_map/draw_base_map.c
+++ b/base_map/draw_base_map.c
@@ -83,43 +83,49 @@ void *draw_map_model(void *arg)
     return ((void *) data);
 }
 
-void	*draw_timer(void *arg)
+int		draw_timer(void *arg)
 {
-  int	error;
-  t_data *data = (t_data*) arg;
-  SDL_Rect timer_panel_rect = {413, 37, 32, 14};
-  SDL_Rect dest_rect_score = {0, 0, WINDOW_W , J_BEGIN * PIXEL_SIZE};
-  SDL_Rect dest_rect_timer = {(WINDOW_W / 2) - ((timer_panel_rect.w / 2) * 5),
-			      (dest_rect_score.h / 2) -
-			      ((timer_panel_rect.h / 2) * 5),
-			      timer_panel_rect.w * 5,
-			      timer_panel_rect.h * 5};
+  int		error;
+  t_data	*data = (t_data*) arg;
+  SDL_Rect	timer_panel_rect = {413, 37, 32, 14};
+  SDL_Rect	dest_rect_score = {0, 0, WINDOW_W , J_BEGIN * PIXEL_SIZE};
+  SDL_Rect	dest_rect_timer = {(WINDOW_W / 2) - ((timer_panel_rect.w / 2) * 5),
+				   (dest_rect_score.h / 2) -
+				   ((timer_panel_rect.h / 2) * 5),
+				   timer_panel_rect.w * 5,
+				   timer_panel_rect.h * 5};
 
   error = SDL_RenderCopy(data->renderer, data->texture,
 			 &timer_panel_rect, &dest_rect_timer);
   data->array_map[0][1] = init_t_map(timer_panel_rect, dest_rect_timer,
 				     timer);
   if (error < 0)
-    SDL_ShowSimpleMessageBox(0, "drawing Timer Failed",
+    {
+      SDL_ShowSimpleMessageBox(0, "drawing Timer Failed",
 			     SDL_GetError(), data->window);
-  return (NULL);
+      return (0);
+    }
+  return (1);
 }
 
-void	*draw_pannel(void *arg)
+int		draw_pannel(void *arg)
 {
-  int	error;
-  t_data *data = (t_data*) arg;
-  SDL_Rect score_panel_rect = {414, 175, 256, 32};
-  SDL_Rect dest_rect_score = {0, 0, WINDOW_W , J_BEGIN * PIXEL_SIZE};
+  int		error;
+  t_data	*data = (t_data*) arg;
+  SDL_Rect	score_panel_rect = {414, 175, 256, 32};
+  SDL_Rect	dest_rect_score = {0, 0, WINDOW_W , J_BEGIN * PIXEL_SIZE};
 
   error = SDL_RenderCopy(data->renderer, data->texture,
 			 &score_panel_rect, &dest_rect_score);
   data->array_map[0][0] = init_t_map(score_panel_rect, dest_rect_score,
 				     pannel);
   if (error < 0)
-    SDL_ShowSimpleMessageBox(0, "drawing Score Tab Failed",
+    {
+      SDL_ShowSimpleMessageBox(0, "drawing Score Tab Failed",
 			     SDL_GetError(), data->window);
-  return (NULL);
+      return (0);
+    }
+  return (1);
 }
 
 void			draw_destroyable_model(void *arg)

--- a/base_map/draw_players.c
+++ b/base_map/draw_players.c
@@ -17,15 +17,47 @@
 #include "player_info.h"
 #include "map.h"
 #include "data.h"
-#include "draw_players.h"
 #include "bomber_sprites.h"
+#include "client_request.h"
+#include "server.h"
+#include "game_info.h"
+#include "draw_players.h"
 
 
-void *draw_player(void *arg, t_player_info player_info)
+int		draw_players(void *arg, t_game_info *client_game_info)
 {
-  int     error;
+  int		i;
+  t_player_info player;
+
+  if (client_game_info != NULL)
+    {
+      for (i = 0; i < 4; i++)
+	{
+	  player = client_game_info->players[i];
+	  printf("\nCheck if player %d is connected and alive: %d %d", player.num_player, player.connected, player.alive);
+	  if (player.connected && player.alive)
+	    {
+	      if (!draw_player(arg, player))
+		return (0);
+	    }
+	}
+    }
+  else
+    {
+      printf("\nclient_game_info is null and must not...\n");
+      return (0);
+    }
+  return (1);
+}
+
+/*
+ * return 1 if success 0 if failure
+ */
+int		draw_player(void *arg, t_player_info player_info)
+{
+  int		error;
   t_data	*data = (t_data*)arg;
-  SDL_Rect sprite_container;
+  SDL_Rect	sprite_container;
 
   sprite_container = getBomberSprites(player_info.num_player, player_info.direction_sprite, player_info.action_sprite);
   SDL_Rect	dest_rect = {player_info.x, player_info.y, PIXEL_SIZE, 24 * 3};
@@ -34,7 +66,10 @@ void *draw_player(void *arg, t_player_info player_info)
 			 &dest_rect);
 
   if (error < 0)
-    SDL_ShowSimpleMessageBox(0, "drawing Player Failed",
+    {
+      SDL_ShowSimpleMessageBox(0, "drawing Player Failed",
 			     SDL_GetError(), data->window);
-  return (NULL);
+      return (0);
+    }
+  return (1);
 }

--- a/includes/base_map_manager.h
+++ b/includes/base_map_manager.h
@@ -15,8 +15,8 @@
 SDL_Rect	pixel_rect(int x, int y);
 SDL_Rect	init_rect(int x, int y, int w, int z);
 t_map		init_t_map(SDL_Rect src, SDL_Rect dest, texture_type type);
-void		*draw_all(void *arg);
-void		*rebuild_map(void *arg);
+int		draw_fixed_map(void *arg);
+void		rebuild_map(void *arg);
 void		build_destroyables(void *arg);
 int		get_element_type(int i, int j);
 

--- a/includes/client_receive.h
+++ b/includes/client_receive.h
@@ -1,7 +1,7 @@
 #ifndef _CLIENT_RECEIVE_H_
 #define _CLIENT_RECEIVE_H_
 
-void *listen_server(void *s);
-int  get_message(int s);
+void	*listen_server(void *s);
+int	get_message(int s, t_game_info *client_game_info);
 
 #endif /* !_CLIENT_RECEIVE_H_ */

--- a/includes/draw_base_map.h
+++ b/includes/draw_base_map.h
@@ -1,9 +1,9 @@
 #ifndef _DRAW_BASE_MAP_H_
 #define _DRAW_BASE_MAP_H_
 
-void *draw_map_model(void *arg);
-void draw_destroyable_model(void *arg);
-void *draw_timer(void *arg);
-void *draw_pannel(void *arg);
+void	*draw_map_model(void *arg);
+void	draw_destroyable_model(void *arg);
+int	draw_timer(void *arg);
+int	draw_pannel(void *arg);
 
 #endif /* !_DRAW_BASE_MAP_H_ */

--- a/includes/draw_players.h
+++ b/includes/draw_players.h
@@ -1,6 +1,7 @@
 #ifndef _DRAW_PLAYER_H_
 #define _DRAW_PLAYER_H_
 
-void *draw_player(void *arg, t_player_info player);
+int	draw_players(void *arg, t_game_info *client_game_info);
+int	draw_player(void *arg, t_player_info player);
 
 #endif /* !_DRAW_PLAYER_H_ */

--- a/start_map.c
+++ b/start_map.c
@@ -16,9 +16,12 @@
 #include "constant.h"
 #include "sdl.h"
 #include "map.h"
-#include "client_receive.h"
 #include "client_request.h"
 #include "player_info.h"
+#include "server.h"
+#include "game_info.h"
+#include "client_receive.h"
+#include "client_request.h"
 #include "data.h"
 #include "thread.h"
 #include "base_map_manager.h"
@@ -44,7 +47,8 @@ int		start_map(t_sdl *sdl, int socket, t_player_request *cr)
   struct_thread->data = data;
   init_sprites_sheet((void *)data);
   initSprites();
-  draw_all((void *)data);
+  if (!draw_fixed_map((void *)data))
+    return (0);
   SDL_SetRenderTarget(data->renderer, NULL);
   SDL_RenderPresent(data->renderer);
   SDL_RenderClear(data->renderer);


### PR DESCRIPTION
## contient

 - Séparation de la game_info cliente de la game_info serveur pour éviter un crash dans le cas d'un client connecté sur le même .exe que le serveur: On crée (malloc) une game_info dans la boucle de reception de client_receive et on set la (*valeur) du (t_game_info*)buff depuis get_message.
- ATTENTION: cela implique de ne plus utilisé les fonctions du singleton game_info depuis le code du client.
 - Toutes les fonctions servant à dessiner et reposant sur la game_info doivent maitnenant recevoir la game_info cliente en paramètre => c'est important!
 - J'ai revu un peu la gestion d'erreur, finis les retours en void ou void* retour sur des int permettant de tester le déroulement des fonctions et d'arrêter le game si ca crash.
 - J'ai séparé le drawing des players du dessin de la map fix pour plus de clarté => draw_players a besoin de la game_info, draw_fixed_map (anciennement draw_all) n'en a pas besoin.